### PR TITLE
Support for new bookmark cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -539,7 +539,8 @@ video {
 .fluid-width-video-wrapper,
 .kg-embed-card,
 .kg-image-card,
-.kg-gallery-card {
+.kg-gallery-card,
+.kg-bookmark-card {
   margin: 0 0 1.66667em;
 }
 
@@ -580,11 +581,102 @@ video {
 }
 
 .kg-image-card figcaption,
-.kg-embed-card figcaption {
+.kg-embed-card figcaption,
+.kg-bookmark-card figcaption {
   color: #9ba6ad;
   font-size: 0.77778rem;
   padding-top: 0.5em;
   text-align: left;
+}
+
+.kg-bookmark-card {
+  width: 100%;
+  position: relative;
+}
+
+.kg-bookmark-container {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row-reverse;
+  color: currentColor;
+  font-family: inherit;
+  text-decoration: none;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 3px;
+}
+
+.kg-bookmark-container:hover {
+  text-decoration: none;
+}
+
+.kg-bookmark-content {
+  flex-basis: 0;
+  flex-grow: 999;
+  padding: 20px;
+  order: 1;
+}
+
+.kg-bookmark-title {
+  font-family: 'Droid Serif',Georgia,serif;
+  font-weight: bold;
+  line-height: 1.33333;
+  text-rendering: optimizeLegibility;
+}
+
+.kg-bookmark-metadata,
+.kg-bookmark-description {
+  margin-top: .5em;
+}
+
+.kg-bookmark-metadata {
+  align-items: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.kg-bookmark-description {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  font-size: 0.88889em;
+}
+
+.kg-bookmark-icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: text-bottom;
+  margin-right: .5em;
+  margin-bottom: .05em;
+}
+
+.kg-bookmark-thumbnail {
+  display: flex;
+  flex-basis: 24rem;
+  flex-grow: 1;
+}
+
+.kg-bookmark-thumbnail img {
+  max-width: 100%;
+  height: auto;
+  vertical-align: bottom;
+  object-fit: cover;
+  border-radius: 0 3px 3px 0;
+}
+
+.kg-bookmark-author, .kg-bookmark-publisher {
+  font-size: 0.88889em;
+  font-weight: bold;
+}
+
+.kg-bookmark-author {
+  display: none;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  color: #9ba6ad;
 }
 
 .footnotes-sep {

--- a/author.hbs
+++ b/author.hbs
@@ -19,17 +19,15 @@
 					<p class="author-bio">{{bio}}</p>
 					{{/if}}
 					<div class="author-meta">
-						{{#if location}}
-						<span class="author-location">{{location}}</span>
-						{{/if}}
+						<span>Find me on:</span>
 						{{#if website}}
 						<span class="author-website"><a href="{{website}}" target="_blank" rel="noopener">{{website}}</a></span>
 						{{/if}}
-						{{#if facebook}}
-						<span class="author-facebook"><a href="{{facebook_url}}" target="_blank" rel="noopener">Facebook</a></span>
-						{{/if}}
 						{{#if twitter}}
 						<span class="author-twitter"><a href="{{twitter_url}}" target="_blank" rel="noopener">Twitter</a></span>
+						{{/if}}
+						{{#if instagram}}
+						<span class="author-instagram"><a href="{{instagram_url}}" target="_blank" rel="noopener">Instagram</a></span>
 						{{/if}}
 					</div><!-- .author-meta -->
 				</div><!-- .author-details -->

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   ],
   "config": {
     "posts_per_page": 6
+  },
+  "engines": {
+    "ghost-api": "v3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "scriptor",
+  "name": "scriptor-herlifeinpixels",
   "description": "Minimal Ghost blogging theme for writers.",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "engines": {
     "ghost": ">=2.22.0"
   },
@@ -14,6 +14,13 @@
     "email": "hello@justgoodthemes.com",
     "url": "https://justgoodthemes.com"
   },
+  "contributors": [
+    {
+      "name": "Hannah Wei",
+      "email": "hannah@herlifeinpixels.com",
+      "url": "https://herlifeinpixels.com"
+    } 
+  ],
    "keywords": [
     "ghost",
     "theme",

--- a/partials/footer.hbs
+++ b/partials/footer.hbs
@@ -3,19 +3,12 @@
 		{{#if @site.twitter}}
 		<a class="twitter-link" href="{{twitter_url}}" target="_blank" rel="noopener"><span class="icon-twitter" aria-hidden="true"></span><span class="screen-reader-text">Twitter</span></a>
 		{{/if}}
-		{{#if @site.facebook}}
-		<a class="facebook-link" href="{{facebook_url}}" target="_blank" rel="noopener"><span class="icon-facebook" aria-hidden="true"></span><span class="screen-reader-text">Facebook</span></a>
-		{{/if}}
-		<a class="google-link" href="#" target="_blank" rel="noopener"><span class="icon-google-plus" aria-hidden="true"></span><span class="screen-reader-text">Google+</span></a>
-		<a class="github-link" href="#" target="_blank" rel="noopener"><span class="icon-github" aria-hidden="true"></span><span class="screen-reader-text">GitHub</span></a>
-		<a class="instagram-link" href="#" target="_blank" rel="noopener"><span class="icon-instagram" aria-hidden="true"></span><span class="screen-reader-text">Instagram</span></a>
-		<a class="pinterest-link" href="#" target="_blank" rel="noopener"><span class="icon-pinterest" aria-hidden="true"></span><span class="screen-reader-text">Pinterest</span></a>
 		<a class="rss-link" href="{{ @site.url }}/rss"><span class="icon-rss" aria-hidden="true"></span><span class="screen-reader-text">RSS Feed</span></a>
 	</div><!-- .offsite-links -->
 	<div class="footer-bottom">
 		<div class="site-info">
 			&copy; {{date format="YYYY"}} <a href="/">{{@site.title}}</a>.<br />
-			Powered by <a target="_blank" href="https://ghost.org/" rel="noopener">Ghost</a>. Scriptor theme by <a target="_blank" href="https://justgoodthemes.com/" rel="noopener">JustGoodThemes</a>.
+			Powered by <a target="_blank" href="https://ghost.org/" rel="noopener">Ghost</a>.
 		</div><!-- .site-info -->
 		<a href="#page" id="back-to-top" class="back-to-top"><span class="screen-reader-text">Back to the top </span>&#8593;</a>
 	</div><!-- .footer-bottom -->

--- a/post.hbs
+++ b/post.hbs
@@ -59,7 +59,4 @@
 	</article>
 	{{/post}}
 
-	{{!-- The tag below includes the theme comments - partials/comments.hbs --}}
-	{{> comments}}
-
 </main><!-- .main-content -->

--- a/post.hbs
+++ b/post.hbs
@@ -40,17 +40,15 @@
 				<p class="author-bio">{{bio}}</p>
 				{{/if}}
 				<div class="author-meta">
-					{{#if location}}
-					<span class="author-location">{{location}}</span>
-					{{/if}}
+					<span>Find me on:</span>
 					{{#if website}}
 					<span class="author-website"><a href="{{website}}" target="_blank" rel="noopener">{{website}}</a></span>
 					{{/if}}
-					{{#if facebook}}
-					<span class="author-facebook"><a href="{{facebook_url}}" target="_blank" rel="noopener">Facebook</a></span>
-					{{/if}}
 					{{#if twitter}}
 					<span class="author-twitter"><a href="{{twitter_url}}" target="_blank" rel="noopener">Twitter</a></span>
+					{{/if}}
+					{{#if instagram}}
+					<span class="author-instagram"><a href="{{instagram_url}}" target="_blank" rel="noopener">Instagram</a></span>
 					{{/if}}
 				</div><!-- .author-meta -->
 			</div><!-- .author-details -->

--- a/post.hbs
+++ b/post.hbs
@@ -26,7 +26,6 @@
 		<div class="share-post">
 			<span>Share this post:</span>
 			<a target="_blank" href="https://twitter.com/intent/tweet?text={{encode title}}&amp;url={{url absolute="true"}}" rel="noopener">Twitter</a>
-			<a target="_blank" href="https://www.facebook.com/sharer.php?u={{url absolute="true"}}" rel="noopener">Facebook</a>
 		</div><!-- .share-post -->
 		{{!-- Everything inside the #author tags pulls data from the author --}}
 		{{#primary_author}}


### PR DESCRIPTION
Currently, adding a bookmark to a page via Ghost's editor will not render properly. Fixed it by:

- Adding some CSS to support new .kg-bookmark classes. See official doc: https://ghost.org/docs/api/v3/handlebars-themes/editor/#bookmark-card
- Updated Content API to use V3 to get rid of the warning
